### PR TITLE
ci: try to generate sass when the repo is tagged with a version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,11 @@ jobs:
           source: theme/source/rockstars.scss
           destination: /tmp/RockstarsRevealTheme/assets/css/rockstars.css
 
-      - name: Checkout destination Git branch
-        uses: actions/checkout@v2
-        with:
-            ref: pr-pages
-            fetch-depth: 1
+          #      - name: Checkout destination Git branch
+          #        uses: actions/checkout@v2
+          #        with:
+          #            ref: pr-pages
+          #            fetch-depth: 1
 
       - name: Move compiled CSS to path within pr-pages branch
         run: mv /tmp/RockstarsRevealTheme/assets/css/rockstars.css assets/


### PR DESCRIPTION
I want to generate a css file when the repo is tagged with a new version. This way, reveal can use the external theme, no need to generate the theme locally.